### PR TITLE
Remove custom Span wrapper, use std::span directly

### DIFF
--- a/benchmarks/sycl/baseline_pipeline.cc
+++ b/benchmarks/sycl/baseline_pipeline.cc
@@ -50,8 +50,8 @@ int main(int argc, char** argv) {
     SyclVector<std::array<real_t,2>> layout2d(BatchSize * N);
     SyclVector<std::array<real_t,3>> xyz     (BatchSize * N);
 
-    Span<std::array<real_t,2>> layout_span(layout2d.data(), layout2d.size());
-    Span<std::array<real_t,3>> xyz_span   (xyz.data(), xyz.size());
+    std::span<std::array<real_t,2>> layout_span(layout2d.data(), layout2d.size());
+    std::span<std::array<real_t,3>> xyz_span   (xyz.data(), xyz.size());
 
     Graph G(Nf, true);
 

--- a/benchmarks/sycl/full_pipeline.cc
+++ b/benchmarks/sycl/full_pipeline.cc
@@ -125,10 +125,10 @@ int main(int argc, char** argv) {
         BuckyGen::stop(BQ);
     }
 
-    Span<std::array<real_t,3>> xyz_span(xyz.data(), xyz.size());
-    Span<std::array<real_t,2>> layout_span(layout2d.data(), layout2d.size());
-    Span<std::array<node_t,6>> faces_cubic_span(faces_cubic_buf.data(), faces_cubic_buf.size());
-    Span<std::array<node_t,3>> faces_dual_span (faces_dual_buf .data(), faces_dual_buf .size());
+    std::span<std::array<real_t,3>> xyz_span(xyz.data(), xyz.size());
+    std::span<std::array<real_t,2>> layout_span(layout2d.data(), layout2d.size());
+    std::span<std::array<node_t,6>> faces_cubic_span(faces_cubic_buf.data(), faces_cubic_buf.size());
+    std::span<std::array<node_t,3>> faces_dual_span (faces_dual_buf .data(), faces_dual_buf .size());
 
     auto src_view = src_dual .view_capacity();
     auto dst_view = dst_cubic.view_capacity();
@@ -152,12 +152,12 @@ int main(int argc, char** argv) {
         auto T8 = std::chrono::steady_clock::now(); times_hessian += std::chrono::duration<double, std::nano>(T8 - T7).count();
         eigensolve_ends.compute(Q, xyz_span, (int)N, BatchSize,
             hessian_buffer, cols_buffer, n_lanczos,
-            spectral_ends_buffer, /*eigenvectors*/Span<real_t>(),
+            spectral_ends_buffer, /*eigenvectors*/std::span<real_t>(),
             off_diagonal, qmat, lanczos_buf, diag_buf, ends_idx).wait();
         auto T9 = std::chrono::steady_clock::now(); times_spectral_ends += std::chrono::duration<double, std::nano>(T9 - T8).count();
         eigensolve_full.compute(Q, xyz_span, (int)N, BatchSize,
             hessian_buffer, cols_buffer, n_lanczos,
-            spectral_buffer, /*eigenvectors*/Span<real_t>(),
+            spectral_buffer, /*eigenvectors*/std::span<real_t>(),
             off_diagonal, qmat, lanczos_buf, diag_buf, ends_idx).wait();
         auto T10 = std::chrono::steady_clock::now(); times_spectral += std::chrono::duration<double, std::nano>(T10 - T9).count();
         auto T11 = std::chrono::steady_clock::now(); times_spectral_vectors += std::chrono::duration<double, std::nano>(T11 - T10).count();

--- a/benchmarks/sycl/full_pipeline_strong_scaling.cc
+++ b/benchmarks/sycl/full_pipeline_strong_scaling.cc
@@ -97,10 +97,10 @@ int main(int argc, char** argv) {
     SphericalProjectionFunctor<real_t, node_t>           spherical_projection;
     ForcefieldOptimizeFunctor<PEDERSEN, real_t, node_t>  forcefield_optimize;
 
-    Span<std::array<real_t,3>> xyz_span(xyz.data(), xyz.size());
-    Span<std::array<real_t,2>> layout_span(layout2d.data(), layout2d.size());
-    Span<std::array<node_t,6>> faces_cubic_span(faces_cubic_buf.data(), faces_cubic_buf.size());
-    Span<std::array<node_t,3>> faces_dual_span (faces_dual_buf .data(), faces_dual_buf .size());
+    std::span<std::array<real_t,3>> xyz_span(xyz.data(), xyz.size());
+    std::span<std::array<real_t,2>> layout_span(layout2d.data(), layout2d.size());
+    std::span<std::array<node_t,6>> faces_cubic_span(faces_cubic_buf.data(), faces_cubic_buf.size());
+    std::span<std::array<node_t,3>> faces_dual_span (faces_dual_buf .data(), faces_dual_buf .size());
 
     auto generate_and_fill = [&]() {
         auto spans = src_dual.view_capacity().spans();

--- a/benchmarks/sycl/lockstep_dualize.cc
+++ b/benchmarks/sycl/lockstep_dualize.cc
@@ -53,8 +53,8 @@ int main(int argc, char** argv) {
 
     SyclVector<std::array<node_t,6>> faces_cubic_buf(BatchSize * Nf);
     SyclVector<std::array<node_t,3>> faces_dual_buf (BatchSize * N);
-    Span<std::array<node_t,6>> faces_cubic_span(faces_cubic_buf.data(), faces_cubic_buf.size());
-    Span<std::array<node_t,3>> faces_dual_span (faces_dual_buf.data(),  faces_dual_buf.size());
+    std::span<std::array<node_t,6>> faces_cubic_span(faces_cubic_buf.data(), faces_cubic_buf.size());
+    std::span<std::array<node_t,3>> faces_dual_span (faces_dual_buf.data(),  faces_dual_buf.size());
 
     Graph G(N);
     auto fill = [&]() {

--- a/include/fullerenes/kernel-headers/base-functor.hh
+++ b/include/fullerenes/kernel-headers/base-functor.hh
@@ -12,15 +12,22 @@ struct is_specialization_of : std::false_type {};
 template <template <typename...> class Template, typename... Args>
 struct is_specialization_of<Template, Template<Args...>> : std::true_type {};
 
+// std::span takes a non-type second parameter (Extent), so is_specialization_of
+// cannot match it. Use a dedicated trait instead.
+template <typename T>
+struct is_std_span : std::false_type {};
+template <typename T, std::size_t N>
+struct is_std_span<std::span<T, N>> : std::true_type {};
+
 template <typename T>
 auto partition_vector(size_t ix, size_t batch_size, const T& value) {
-    if constexpr (is_specialization_of<SyclVector, T>::value || is_specialization_of<Span, T>::value) {
+    if constexpr (is_specialization_of<SyclVector, T>::value || is_std_span<T>::value) {
         auto size = value.size();
         if (size % batch_size != 0) {
             throw std::runtime_error("The size of the SyclVector is not divisible by the batch size");
         }
         auto size_per_isomer = size / batch_size;
-        auto modified = Span(value.begin() + ix*size_per_isomer, value.begin() + (ix+1)*size_per_isomer);
+        auto modified = std::span(value.begin() + ix*size_per_isomer, value.begin() + (ix+1)*size_per_isomer);
         return modified;
     } else {
         return value;  // Leave other types unchanged
@@ -74,10 +81,10 @@ struct FunctorArrays : public ArrayOfSyclVectors<T> {
         return this->at((size_t)device_type);
     }
 
-    Span<T> operator[](const std::pair<Device, size_t> ix_tuple) {
+    std::span<T> operator[](const std::pair<Device, size_t> ix_tuple) {
         return this->at((size_t)ix_tuple.first.type).at(ix_tuple.first.idx).at(ix_tuple.second);
     }
-    Span<T> operator[](const std::pair<SyclQueue&, size_t> ix_tuple) {
+    std::span<T> operator[](const std::pair<SyclQueue&, size_t> ix_tuple) {
         auto& [Q, ix] = ix_tuple;
         return (*this)[std::pair<Device,size_t>{Q.device(), ix}];
     }

--- a/include/fullerenes/kernel-headers/dualize-functor.hh
+++ b/include/fullerenes/kernel-headers/dualize-functor.hh
@@ -22,8 +22,8 @@ struct DualizeFunctor : public KernelFunctor<DualizeFunctor<T,K>> {
                       batch::BatchView<Spanify::RSRAdjacencyView<K>> src,
                       batch::BatchView<Spanify::RSRAdjacencyView<K>> dst,
                       batch::BatchStateView                          state,
-                      Span<std::array<K,6>>                          faces_cubic,
-                      Span<std::array<K,3>>                          faces_dual);
+                      std::span<std::array<K,6>>                          faces_cubic,
+                      std::span<std::array<K,3>>                          faces_dual);
 
     mutable FunctorArrays<K> cannon_ixs_;
     mutable FunctorArrays<K> rep_count_;

--- a/include/fullerenes/kernel-headers/eigen-functor.hh
+++ b/include/fullerenes/kernel-headers/eigen-functor.hh
@@ -9,12 +9,12 @@ struct EigenFunctor : public KernelFunctor<EigenFunctor<mode, T, K>> {
     // View-based batch overload (Phase 7).
     // xyz:         capacity*N 3D coordinates (read-only, for deflation against rigid-body modes).
     SyclEvent compute(SyclQueue& Q,
-                      Span<std::array<T,3>> xyz,
+                      std::span<std::array<T,3>> xyz,
                       int N, int capacity,
-                      Span<T> hessian, Span<K> cols, size_t n_lanczos,
-                      Span<T> eigenvalues, Span<T> eigenvectors,
-                      Span<T> off_diagonal, Span<T> qmat,
-                      Span<T> lanczos, Span<T> diag, Span<K> ends_idx);
+                      std::span<T> hessian, std::span<K> cols, size_t n_lanczos,
+                      std::span<T> eigenvalues, std::span<T> eigenvectors,
+                      std::span<T> off_diagonal, std::span<T> qmat,
+                      std::span<T> lanczos, std::span<T> diag, std::span<K> ends_idx);
 
 
     mutable FunctorArrays<K> indices_;
@@ -25,7 +25,7 @@ struct EigenFunctor : public KernelFunctor<EigenFunctor<mode, T, K>> {
     mutable FunctorArrays<K> ends_idx_;
 
     template <typename... Args>
-    inline constexpr auto to_tuple(size_t N, Span<T> hessian, Span<K> cols, size_t n_lanczos, Args&&... args) const {
+    inline constexpr auto to_tuple(size_t N, std::span<T> hessian, std::span<K> cols, size_t n_lanczos, Args&&... args) const {
         return  std::make_tuple(
                 std::make_pair(std::ref(indices_), N),
                 std::make_pair(std::ref(off_diagonal_), n_lanczos),
@@ -37,7 +37,7 @@ struct EigenFunctor : public KernelFunctor<EigenFunctor<mode, T, K>> {
     }
 
     template <typename... Args>
-    inline constexpr auto to_tuple_batch(size_t N, Span<T> hessian, Span<K> cols, size_t n_lanczos, Args&&... args) const {
+    inline constexpr auto to_tuple_batch(size_t N, std::span<T> hessian, std::span<K> cols, size_t n_lanczos, Args&&... args) const {
         return std::make_tuple(
                 std::make_pair(std::ref(off_diagonal_), n_lanczos),
                 std::make_pair(std::ref(qmat_), n_lanczos*n_lanczos),

--- a/include/fullerenes/kernel-headers/forcefield-optimize-functor.hh
+++ b/include/fullerenes/kernel-headers/forcefield-optimize-functor.hh
@@ -13,7 +13,7 @@ struct ForcefieldOptimizeFunctor: public KernelFunctor<ForcefieldOptimizeFunctor
     //              state.iteration[i] is incremented by batch_iters each call.
     SyclEvent compute(SyclQueue& Q,
                       batch::BatchView<Spanify::RSRAdjacencyView<K>> graph,
-                      Span<std::array<T,3>>                          xyz,
+                      std::span<std::array<T,3>>                          xyz,
                       batch::BatchStateView                          state,
                       size_t batch_iters, size_t max_iters);
 

--- a/include/fullerenes/kernel-headers/geometry-functors.hh
+++ b/include/fullerenes/kernel-headers/geometry-functors.hh
@@ -6,27 +6,27 @@
 template<typename T, typename K>
 struct EccentricityFunctor : public KernelFunctor<EccentricityFunctor<T, K>> {
     // View-based overload (Phase 7). xyz: capacity*N 3D coords.
-    SyclEvent compute(SyclQueue& Q, Span<std::array<T,3>> xyz, int N, int capacity,
-                      batch::BatchStateView state, Span<T> out_ellipticity);
+    SyclEvent compute(SyclQueue& Q, std::span<std::array<T,3>> xyz, int N, int capacity,
+                      batch::BatchStateView state, std::span<T> out_ellipticity);
 
-    inline constexpr auto to_tuple(size_t N, Span<T> out_ellipticity) const {       return std::make_tuple();}
-    inline constexpr auto to_tuple_batch(size_t N, Span<T> out_ellipticity) const { return std::make_tuple();}
+    inline constexpr auto to_tuple(size_t N, std::span<T> out_ellipticity) const {       return std::make_tuple();}
+    inline constexpr auto to_tuple_batch(size_t N, std::span<T> out_ellipticity) const { return std::make_tuple();}
 };
 
 template<typename T, typename K>
 struct InertiaFunctor : public KernelFunctor<InertiaFunctor<T, K>> {
     // View-based overload (Phase 7). xyz: capacity*N 3D coords.
-    SyclEvent compute(SyclQueue& Q, Span<std::array<T,3>> xyz, int N, int capacity,
-                      batch::BatchStateView state, Span<std::array<T,3>> out_inertia);
+    SyclEvent compute(SyclQueue& Q, std::span<std::array<T,3>> xyz, int N, int capacity,
+                      batch::BatchStateView state, std::span<std::array<T,3>> out_inertia);
 
-    inline constexpr auto to_tuple(size_t N, Span<std::array<T,3>> out_inertia) const {       return std::make_tuple();}
-    inline constexpr auto to_tuple_batch(size_t N, Span<std::array<T,3>> out_inertia) const { return std::make_tuple();}
+    inline constexpr auto to_tuple(size_t N, std::span<std::array<T,3>> out_inertia) const {       return std::make_tuple();}
+    inline constexpr auto to_tuple_batch(size_t N, std::span<std::array<T,3>> out_inertia) const { return std::make_tuple();}
 };
 
 template<typename T, typename K>
 struct TransformCoordinatesFunctor : public KernelFunctor<TransformCoordinatesFunctor<T, K>> {
     // View-based overload (Phase 7). xyz: capacity*N 3D coords, updated in-place.
-    SyclEvent compute(SyclQueue& Q, Span<std::array<T,3>> xyz, int N, int capacity,
+    SyclEvent compute(SyclQueue& Q, std::span<std::array<T,3>> xyz, int N, int capacity,
                       batch::BatchStateView state);
 
     inline constexpr auto to_tuple(size_t N ) const {       return std::make_tuple();}
@@ -38,29 +38,29 @@ struct SurfaceAreaFunctor : public KernelFunctor<SurfaceAreaFunctor<T, K>> {
     // View-based overload (Phase 7).
     // xyz: capacity*N 3D coords; faces: capacity*Nf arrays of up to 6 node indices;
     // deg: capacity*Nf face degree (5 or 6).
-    SyclEvent compute(SyclQueue& Q, Span<std::array<T,3>> xyz, int N, int capacity,
-                      Span<std::array<K,6>> faces, Span<uint8_t> deg,
-                      batch::BatchStateView state, Span<T> out_surface_area);
+    SyclEvent compute(SyclQueue& Q, std::span<std::array<T,3>> xyz, int N, int capacity,
+                      std::span<std::array<K,6>> faces, std::span<uint8_t> deg,
+                      batch::BatchStateView state, std::span<T> out_surface_area);
 
     mutable FunctorArrays<K> indices_;
 
-    inline constexpr auto to_tuple(size_t N, Span<T> out_surface_area) const {
+    inline constexpr auto to_tuple(size_t N, std::span<T> out_surface_area) const {
         auto Nf = N/2 + 2;       
         return std::make_tuple(std::make_pair(std::ref(indices_), Nf));}
-    inline constexpr auto to_tuple_batch(size_t N, Span<T> out_surface_area) const { return std::make_tuple();}
+    inline constexpr auto to_tuple_batch(size_t N, std::span<T> out_surface_area) const { return std::make_tuple();}
 };
 
 template<typename T, typename K>
 struct VolumeFunctor : public KernelFunctor<VolumeFunctor<T, K>> {
     // View-based overload (Phase 7). Same parameters as SurfaceAreaFunctor view overload.
-    SyclEvent compute(SyclQueue& Q, Span<std::array<T,3>> xyz, int N, int capacity,
-                      Span<std::array<K,6>> faces, Span<uint8_t> deg,
-                      batch::BatchStateView state, Span<T> out_volume);
+    SyclEvent compute(SyclQueue& Q, std::span<std::array<T,3>> xyz, int N, int capacity,
+                      std::span<std::array<K,6>> faces, std::span<uint8_t> deg,
+                      batch::BatchStateView state, std::span<T> out_volume);
 
     mutable FunctorArrays<K> indices_;
 
-    inline constexpr auto to_tuple(size_t N, Span<T> out_volume) const {
+    inline constexpr auto to_tuple(size_t N, std::span<T> out_volume) const {
         auto Nf = N/2 + 2;
         return std::make_tuple(std::make_pair(std::ref(indices_), Nf));}
-    inline constexpr auto to_tuple_batch(size_t N, Span<T> out_volume) const { return std::make_tuple();}
+    inline constexpr auto to_tuple_batch(size_t N, std::span<T> out_volume) const { return std::make_tuple();}
 };

--- a/include/fullerenes/kernel-headers/hessian-functor.hh
+++ b/include/fullerenes/kernel-headers/hessian-functor.hh
@@ -14,19 +14,19 @@ struct HessianFunctor : public KernelFunctor<HessianFunctor<FFT, T, K>> {
     // out_cols:    column index arrays,     must be >= 90*N*capacity.
     SyclEvent compute(SyclQueue& Q,
                       batch::BatchView<Spanify::RSRAdjacencyView<K>> graph,
-                      Span<std::array<T,3>>                          xyz,
+                      std::span<std::array<T,3>>                          xyz,
                       batch::BatchStateView                          state,
-                      Span<T> out_hessian, Span<K> out_cols);
+                      std::span<T> out_hessian, std::span<K> out_cols);
 
     mutable FunctorArrays<K> indices_;
 
-    inline constexpr auto to_tuple(size_t N, Span<T> out_hessian, Span<K> out_cols) const {
+    inline constexpr auto to_tuple(size_t N, std::span<T> out_hessian, std::span<K> out_cols) const {
         return  std::make_tuple(
                 std::make_pair(std::ref(indices_), N)
                 );
     }
 
-    inline constexpr auto to_tuple_batch(size_t N, Span<T> out_hessian, Span<K> out_cols) const {
+    inline constexpr auto to_tuple_batch(size_t N, std::span<T> out_hessian, std::span<K> out_cols) const {
         return std::make_tuple();
     }
 };

--- a/include/fullerenes/kernel-headers/spherical-projection-functor.hh
+++ b/include/fullerenes/kernel-headers/spherical-projection-functor.hh
@@ -14,8 +14,8 @@ struct SphericalProjectionFunctor : public KernelFunctor<SphericalProjectionFunc
     // state:      per-entry status; honours FULLERENEGRAPH_PREPARED, sets NOT_CONVERGED.
     SyclEvent compute(SyclQueue& Q,
                       batch::BatchView<Spanify::RSRAdjacencyView<K>> graph,
-                      Span<std::array<T,2>>                          layout_2d,
-                      Span<std::array<T,3>>                          xyz_3d,
+                      std::span<std::array<T,2>>                          layout_2d,
+                      std::span<std::array<T,3>>                          xyz_3d,
                       batch::BatchStateView                          state);
 
     mutable FunctorArrays<K> topological_distances_;

--- a/include/fullerenes/kernel-headers/tutte-functor.hh
+++ b/include/fullerenes/kernel-headers/tutte-functor.hh
@@ -12,7 +12,7 @@ struct TutteFunctor : public KernelFunctor<TutteFunctor<T,K>> {
     // state: per-entry status; honours FULLERENEGRAPH_PREPARED, sets CONVERGED_2D.
     SyclEvent compute(SyclQueue& Q,
                       batch::BatchView<Spanify::RSRAdjacencyView<K>> graph,
-                      Span<std::array<T,2>>                          layout,
+                      std::span<std::array<T,2>>                          layout,
                       batch::BatchStateView                          state);
 
     mutable FunctorArrays<std::array<T,2>> newxys_;

--- a/include/fullerenes/mempool.hh
+++ b/include/fullerenes/mempool.hh
@@ -9,7 +9,7 @@ struct BumpAllocator {
     BumpAllocator(T* data, size_t byte_size): data(data), byte_size(byte_size){}
 
     template <typename T>
-    BumpAllocator(Span<T> span): data(span.data()), byte_size(span.size()*sizeof(T)){}
+    BumpAllocator(std::span<T> span): data(span.data()), byte_size(span.size()*sizeof(T)){}
 
     template<typename T>
     constexpr inline static auto alignment(const Device& device){
@@ -27,7 +27,7 @@ struct BumpAllocator {
     constexpr inline static size_t allocation_size(SyclQueue& ctx, size_t size)   {return allocation_size<T>(ctx.device(), size);}
 
     template<typename T>
-    constexpr inline Span<T> allocate(const Device& device, size_t size){
+    constexpr inline std::span<T> allocate(const Device& device, size_t size){
         size_t alloc_size = allocation_size<T>(device,size);
         if (alloc_size > byte_size){
             throw std::runtime_error("Out of memory");
@@ -40,11 +40,11 @@ struct BumpAllocator {
         data = reinterpret_cast<void*>(ptr + size);
         byte_size -= (reinterpret_cast<char*>(data) - reinterpret_cast<char*>(ptr));
 
-        return Span(ptr, size);
+        return std::span(ptr, size);
     }
 
     template<typename T>
-    constexpr inline Span<T> allocate(SyclQueue& ctx, size_t size) {return allocate<T>(ctx.device(), size);}
+    constexpr inline std::span<T> allocate(SyclQueue& ctx, size_t size) {return allocate<T>(ctx.device(), size);}
     
     private:
 

--- a/include/fullerenes/sycl-headers/sycl-mdspan.hh
+++ b/include/fullerenes/sycl-headers/sycl-mdspan.hh
@@ -157,7 +157,7 @@ struct MDSpan
     inline constexpr T& operator[](const array_t &index)  {
         for(int axis=0;axis<N;axis++){
             if(index[axis] >= shape_[axis]){
-                std::cout << "index = " << Span(const_cast<int*>(index.data()), N) << "\n";
+                std::cout << "index = " << std::span(const_cast<int*>(index.data()), N) << "\n";
                 printf("axis = %d, index[axis] = %d, shape_[axis] = %d\n", axis, index[axis], shape_[axis]);
             }
              assert(index[axis] < shape_[axis]); // TODO: Langsomt, til debug naar virker
@@ -171,9 +171,9 @@ struct MDSpan
         assert(data_ != 0); 
         size_t offset = offset_of<N>(index);
         if(0) if(offset >= size()){
-            std::cout << "index = " << Span(const_cast<int*>(index.data()),N) << " -> " << offset << " >= " << size() << "\n";
-            std::cout << "stride = " << Span(const_cast<int*>(stride_.data()),N) << "\n";
-            std::cout << "shape = " << Span(const_cast<int*>(shape_.data()),N) << "\n";
+            std::cout << "index = " << std::span(const_cast<int*>(index.data()),N) << " -> " << offset << " >= " << size() << "\n";
+            std::cout << "stride = " << std::span(const_cast<int*>(stride_.data()),N) << "\n";
+            std::cout << "shape = " << std::span(const_cast<int*>(shape_.data()),N) << "\n";
         }
         return data_[offset];
     }    

--- a/include/fullerenes/sycl-headers/sycl-span.hh
+++ b/include/fullerenes/sycl-headers/sycl-span.hh
@@ -1,8 +1,4 @@
 #pragma once
-// Phase 9: Span<T> is a thin wrapper around std::span<T> that keeps the
-// extra `as_span<U>()` reinterpret helper used pervasively by the SYCL
-// kernels. All other behaviour is inherited from std::span.
-
 #include <span>
 #include <ostream>
 #include <algorithm>
@@ -11,50 +7,12 @@
 #include <type_traits>
 #include <cstddef>
 
-template <typename T>
-struct Span : public std::span<T> {
-    using base = std::span<T>;
-    using base::base;                          // inherit std::span constructors
-    using typename base::element_type;
-    using typename base::value_type;
-    using typename base::size_type;
-
-    constexpr Span() noexcept = default;
-    constexpr Span(const Span&) noexcept = default;
-    constexpr Span& operator=(const Span&) noexcept = default;
-    constexpr Span(base b) noexcept : base(b) {}
-
-    // Convert any pointer-like object (e.g. sycl::multi_ptr) to T* and wrap
-    // it as a span of `sz` elements. Needed because std::span's (It, size)
-    // constructor requires `It` to satisfy std::contiguous_iterator, which
-    // SYCL's multi_ptr does not. Excluded for raw pointers to avoid
-    // ambiguity with the inherited std::span(T*, size_type) ctor.
-    template <typename Ptr,
-              typename = std::enable_if_t<!std::is_pointer_v<std::decay_t<Ptr>>>,
-              typename = decltype(static_cast<T*>(std::declval<Ptr&>()))>
-    constexpr Span(Ptr&& p, std::size_t sz)
-        : base(static_cast<T*>(p), sz) {}
-
-    // Reinterpret-cast view of the underlying storage as a span of U.
-    template <typename U>
-    constexpr Span<U> as_span() const {
-        return Span<U>(reinterpret_cast<U*>(this->data()),
-                       (this->size() * sizeof(T)) / sizeof(U));
-    }
-
-    // Override subspan so it returns a Span<T>, preserving as_span<U>()
-    // chaining in existing call sites.
-    constexpr Span<T> subspan(size_type offset) const {
-        return Span<T>(this->data() + offset, this->size() - offset);
-    }
-    constexpr Span<T> subspan(size_type offset, size_type count) const {
-        return Span<T>(this->data() + offset, count);
-    }
-};
-
-// Deduction guides – cover raw pointers, iterator pairs, and iterator+size.
-template <typename T> Span(T*, std::size_t) -> Span<T>;
-template <typename It> Span(It, It) -> Span<typename std::iterator_traits<It>::value_type>;
+// Reinterpret-cast a std::span<T> as a std::span<U>.
+template <typename U, typename T>
+constexpr std::span<U> as_span(std::span<T> s) {
+    return std::span<U>(reinterpret_cast<U*>(s.data()),
+                        (s.size() * sizeof(T)) / sizeof(U));
+}
 
 template <typename T>
 inline std::ostream& operator<<(std::ostream& os, std::span<T> v) {

--- a/include/fullerenes/sycl-headers/sycl-vector.hh
+++ b/include/fullerenes/sycl-headers/sycl-vector.hh
@@ -38,10 +38,10 @@ struct SyclVector
         return *this;
     }
 
-    inline constexpr operator Span<T>() const { return Span<T>(data_, size_); }
-    inline constexpr Span<T> to_span() const { return Span<T>(data_, size_); }
-    inline constexpr Span<T> subspan(size_t offset, size_t count) const { return Span<T>(data_ + offset, count); }
-    inline constexpr Span<T> subspan(size_t offset) const { return Span<T>(data_ + offset, size_ - offset); }
+    inline constexpr operator std::span<T>() const { return std::span<T>(data_, size_); }
+    inline constexpr std::span<T> to_span() const { return std::span<T>(data_, size_); }
+    inline constexpr std::span<T> subspan(size_t offset, size_t count) const { return std::span<T>(data_ + offset, count); }
+    inline constexpr std::span<T> subspan(size_t offset) const { return std::span<T>(data_ + offset, size_ - offset); }
     inline constexpr void fill(T data) { std::fill(begin(), end(), data); }
     inline constexpr T *data() const { return data_; }
     inline constexpr size_t size() const { return size_; }
@@ -57,7 +57,7 @@ struct SyclVector
     inline constexpr const T &at(size_t index) const { assert(index < size_); return data_[index]; }
 
     inline constexpr bool operator==(const SyclVector<T> &other) const {
-        return span_fuzzy_equal(Span<T>(*this), Span<T>(other));
+        return span_fuzzy_equal(std::span<T>(*this), std::span<T>(other));
     }
 
     inline constexpr void push_back(const T &value) { 

--- a/src/sycl/constants.cc
+++ b/src/sycl/constants.cc
@@ -33,7 +33,7 @@ struct Constants{
     coord3d outer_dih0_m;
     coord3d outer_dih0_p;
 
-    inline Constants(const Span<std::array<K,3>> cubic_neighbours, K idx){
+    inline Constants(const std::span<std::array<K,3>> cubic_neighbours, K idx){
 
         constexpr real_t optimal_corner_cos_angles[2] = {-0.30901699437494734, -0.5}; 
         constexpr real_t optimal_bond_lengths[3] = {1.479, 1.458, 1.401}; 

--- a/src/sycl/cubic-graph.cc
+++ b/src/sycl/cubic-graph.cc
@@ -6,13 +6,13 @@ struct DeviceCubicGraph{
     static_assert(std::is_integral<K>::value, "K must be integral");
     //const accessor<K, 1, access::mode::read> cubic_neighbours;
     //const size_t offset;
-    const Span<std::array<K,3>> cubic_neighbours;
+    const std::span<std::array<K,3>> cubic_neighbours;
 
     inline std::array<K,3> operator[](const K i) const{
         return cubic_neighbours[i];
     }
 
-    DeviceCubicGraph(const Span<std::array<K,3>> cubic_neighbours) : cubic_neighbours(cubic_neighbours) {}
+    DeviceCubicGraph(const std::span<std::array<K,3>> cubic_neighbours) : cubic_neighbours(cubic_neighbours) {}
 
     /** @brief Find the index of the neighbour v in the list of neighbours of u
     // @param u: source node in the arc (u,v)

--- a/src/sycl/deigen-batch.cc
+++ b/src/sycl/deigen-batch.cc
@@ -219,9 +219,9 @@ void T_QTQ(const int n, MDSpan<real_t,1> Din, MDSpan<real_t,1> Lin, MDSpan<real_
     }
   }
 
-  std::cout << "D = " << Span(D.data(),n) << ";\n";
-  std::cout << "L = " << Span(L.data(),n) << ";\n";
-  std::cout << "U = " << Span(U.data(),2*(n+1)) << ";\n";
+  std::cout << "D = " << std::span(D.data(),n) << ";\n";
+  std::cout << "L = " << std::span(L.data(),n) << ";\n";
+  std::cout << "U = " << std::span(U.data(),2*(n+1)) << ";\n";
 
   for(int k=0;k<n-1;k++)
     if(fabs(L[k]) > numerical_zero)  // Only process if subdiagonal element is not already zero.

--- a/src/sycl/dualize.cc
+++ b/src/sycl/dualize.cc
@@ -17,10 +17,10 @@ struct DeviceDualGraph{
     //Check that K is integral
     INT_TYPEDEFS(K);
     
-    const Span<std::array<K,MaxDegree>> dual_neighbours;                          //(Nf x MaxDegree)
-    const Span<DegT> face_degrees;                            //(Nf x 1)
+    const std::span<std::array<K,MaxDegree>> dual_neighbours;                          //(Nf x MaxDegree)
+    const std::span<DegT> face_degrees;                            //(Nf x 1)
     
-    DeviceDualGraph(const Span<std::array<K,MaxDegree>> dual_neighbours, const Span<DegT> face_degrees) : dual_neighbours(dual_neighbours), face_degrees(face_degrees) {}
+    DeviceDualGraph(const std::span<std::array<K,MaxDegree>> dual_neighbours, const std::span<DegT> face_degrees) : dual_neighbours(dual_neighbours), face_degrees(face_degrees) {}
 
     K arc_ix(const K u, const K v) const{
         for (uint8_t j = 0; j < face_degrees[u]; j++){
@@ -81,15 +81,15 @@ int roundUp(int numToRound, int multiple)
 
 template<typename T, typename K, int MaxDegIn, int MaxDegOut>
 SyclEvent dualize_general_impl(  SyclQueue& Q, 
-                            Span<K> G_in, 
-                            Span<K> Deg_in, 
-                            Span<K> G_out, 
-                            Span<K> Deg_out,
-                            Span<K> cannon_ixs_acc,
-                            Span<K> rep_count_acc,
-                            Span<K> scan_array_acc,
-                            Span<K> triangle_numbers_acc,
-                            Span<K> arc_list_acc, 
+                            std::span<K> G_in, 
+                            std::span<K> Deg_in, 
+                            std::span<K> G_out, 
+                            std::span<K> Deg_out,
+                            std::span<K> cannon_ixs_acc,
+                            std::span<K> rep_count_acc,
+                            std::span<K> scan_array_acc,
+                            std::span<K> triangle_numbers_acc,
+                            std::span<K> arc_list_acc, 
                             int Nin, 
                             int Nout){
     INT_TYPEDEFS(K);
@@ -180,8 +180,8 @@ static SyclEvent dualize_view_batch_impl(SyclQueue& Q,
                                          batch::BatchView<Spanify::RSRAdjacencyView<K>> src,
                                          batch::BatchView<Spanify::RSRAdjacencyView<K>> dst,
                                          batch::BatchStateView                          state,
-                                         Span<std::array<K,6>> faces_cubic_scratch,
-                                         Span<std::array<K,3>> faces_dual_scratch)
+                                         std::span<std::array<K,6>> faces_cubic_scratch,
+                                         std::span<std::array<K,3>> faces_dual_scratch)
 {
     INT_TYPEDEFS(K);
     constexpr int     MaxDegree  = 6;
@@ -200,16 +200,16 @@ static SyclEvent dualize_view_batch_impl(SyclQueue& Q,
 
     // Wrap as project Spans (pointer,size) with the typed-row shapes the
     // kernel wants.
-    Span<std::array<K,MaxDegree>> A_dual(
+    std::span<std::array<K,MaxDegree>> A_dual(
         reinterpret_cast<std::array<K,MaxDegree>*>(src_adj_std.data()),
         src_adj_std.size() / MaxDegree);
-    Span<uint8_t> deg(src_deg_std.data(), src_deg_std.size());
-    Span<std::array<K,3>> A_cubic(
+    std::span<uint8_t> deg(src_deg_std.data(), src_deg_std.size());
+    std::span<std::array<K,3>> A_cubic(
         reinterpret_cast<std::array<K,3>*>(dst_adj_std.data()),
         dst_adj_std.size() / 3);
-    Span<std::array<K,MaxDegree>> faces_cubic = faces_cubic_scratch;
-    Span<std::array<K,3>>         faces_dual  = faces_dual_scratch;
-    Span<StatusFlag> statuses(state.status.data(), state.status.size());
+    std::span<std::array<K,MaxDegree>> faces_cubic = faces_cubic_scratch;
+    std::span<std::array<K,3>>         faces_dual  = faces_dual_scratch;
+    std::span<StatusFlag> statuses(state.status.data(), state.status.size());
 
     SyclEventImpl cubic_graph_event = Q->submit([&](handler &h) {
         local_accessor<std::array<K,MaxDegree>, 1> triangle_numbers(Nf, h);
@@ -231,8 +231,8 @@ static SyclEvent dualize_view_batch_impl(SyclQueue& Q,
             }
 
             DeviceDualGraph<MaxDegree, node_t, node_t> FD(
-                Span<std::array<K,MaxDegree>>(cached_neighbours.get_pointer(), Nf),
-                Span<node_t>(cached_degrees.get_pointer(), Nf));
+                std::span<std::array<K,MaxDegree>>(static_cast<std::array<K,MaxDegree>*>(cached_neighbours.get_pointer()), Nf),
+                std::span<node_t>(static_cast<node_t*>(cached_degrees.get_pointer()), Nf));
 
             node_t canon_arcs[MaxDegree];
             for (size_t i = 0; i < MaxDegree; i++) canon_arcs[i] = EMPTY_NODE;
@@ -302,8 +302,8 @@ SyclEvent DualizeFunctor<T,K>::compute(SyclQueue& Q,
                                        batch::BatchView<Spanify::RSRAdjacencyView<K>> src,
                                        batch::BatchView<Spanify::RSRAdjacencyView<K>> dst,
                                        batch::BatchStateView                          state,
-                                       Span<std::array<K,6>>                          faces_cubic,
-                                       Span<std::array<K,3>>                          faces_dual)
+                                       std::span<std::array<K,6>>                          faces_cubic,
+                                       std::span<std::array<K,3>>                          faces_dual)
 {
     return dualize_view_batch_impl<T,K>(Q, src, dst, state, faces_cubic, faces_dual);
 }

--- a/src/sycl/eigen.cc
+++ b/src/sycl/eigen.cc
@@ -259,18 +259,18 @@ struct EigenBuffers{
  */
 template <EigensolveMode mode, typename T, typename K>
 SyclEvent eigensolve_impl(SyclQueue& Q,
-                            Span<std::array<T,3>> X_acc,
+                            std::span<std::array<T,3>> X_acc,
                             size_t Natoms, size_t batch_size,
-                            Span<T> hessians, 
-                            Span<K> cols, 
+                            std::span<T> hessians, 
+                            std::span<K> cols, 
                             size_t _nLanczos, 
-                            Span<T> eigenvalues, 
-                            Span<T> eigenvectors,
-                            Span<T> off_diagonal,
-                            Span<T> qmat,
-                            Span<T> lanczos,
-                            Span<T> diag,
-                            Span<K> ends_idx){
+                            std::span<T> eigenvalues, 
+                            std::span<T> eigenvectors,
+                            std::span<T> off_diagonal,
+                            std::span<T> qmat,
+                            std::span<T> lanczos,
+                            std::span<T> diag,
+                            std::span<K> ends_idx){
     TEMPLATE_TYPEDEFS(T,K);
     //If mode is ENDS or ENDS_VECTORS, we can make do with fewer lanczos iterations, default is 50.
     size_t nLanczos = (mode == EigensolveMode::ENDS || mode == EigensolveMode::ENDS_VECTORS) ? _nLanczos : Natoms*3 - 6; //-6 for 6 degrees of freedom
@@ -524,7 +524,7 @@ SyclEvent eigensolve_impl(SyclQueue& Q,
             for(int i = 0; i < 3; i++){
                 e[i*n + tid] = real_t(tid%3 == i)/sqrt(Natoms); 
             }
-            coord3d* X_ptr = X_acc.template as_span<coord3d>().data() + Natoms*bid;
+            coord3d* X_ptr = as_span<coord3d>(X_acc).data() + Natoms*bid;
             if (tid%3 == 0) {
                 e[3*n + tid] = real_t(0.);
                 e[4*n + tid] = -X_ptr[atom_idx][2];
@@ -585,28 +585,28 @@ SyclEvent eigensolve_impl(SyclQueue& Q,
 template <EigensolveMode mode, typename T, typename K>
 SyclEvent EigenFunctor<mode, T, K>::compute(
     SyclQueue& Q,
-    Span<std::array<T,3>> xyz,
+    std::span<std::array<T,3>> xyz,
     int N, int capacity,
-    Span<T> hessians, Span<K> cols, size_t n_lanczos,
-    Span<T> eigenvalues, Span<T> eigenvectors,
-    Span<T> off_diagonal, Span<T> qmat,
-    Span<T> lanczos, Span<T> diag, Span<K> ends_idx)
+    std::span<T> hessians, std::span<K> cols, size_t n_lanczos,
+    std::span<T> eigenvalues, std::span<T> eigenvectors,
+    std::span<T> off_diagonal, std::span<T> qmat,
+    std::span<T> lanczos, std::span<T> diag, std::span<K> ends_idx)
 {
     // eigensolve<mode> only accesses B.d_.X_cubic_, B.N_, and B.size().
     // Build a thin proxy that satisfies those.
     struct XyzProxy {
-        Span<std::array<T,3>> d_X;
+        std::span<std::array<T,3>> d_X;
         size_t N_;
         int    size_;
         // The struct is accessed as B.d_.X_cubic_, B.N_, B.size() in eigensolve.
-        struct D { Span<std::array<T,3>> X_cubic_; } d_;
+        struct D { std::span<std::array<T,3>> X_cubic_; } d_;
         int size() const { return size_; }
         // Provide the same interface as FullereneBatchView for eigensolve.
-        XyzProxy(Span<std::array<T,3>> xyz, int N, int cap)
+        XyzProxy(std::span<std::array<T,3>> xyz, int N, int cap)
             : d_X(xyz), N_(N), size_(cap) { d_.X_cubic_ = xyz; }
     };
     return eigensolve_impl<mode,T,K>(Q,
-        xyz.template as_span<std::array<T,3>>(),
+        as_span<std::array<T,3>>(xyz),
         (size_t)N, (size_t)capacity,
         hessians, cols, n_lanczos,
         eigenvalues, eigenvectors,

--- a/src/sycl/forcefield-optimize.cc
+++ b/src/sycl/forcefield-optimize.cc
@@ -62,7 +62,7 @@ struct ForceField
         node_t node_id;
         sycl::group<1> cta;
         // 84 + 107 FLOPS
-        FaceData(const sycl::group<1> &cta, const Span<coord3d> X, const NodeNeighbours<K> &G) : cta(cta)
+        FaceData(const sycl::group<1> &cta, const std::span<coord3d> X, const NodeNeighbours<K> &G) : cta(cta)
         {
             node_id = cta.get_local_linear_id();
             N = cta.get_local_linear_range();
@@ -187,7 +187,7 @@ struct ForceField
          * @param G The neighbour information for the threadIdx^th node.
          * @return A new ArcData object.
          */
-        ArcData(node_t a, const int j, const Span<coord3d> X, const NodeNeighbours<K> &G)
+        ArcData(node_t a, const int j, const std::span<coord3d> X, const NodeNeighbours<K> &G)
         {
             __builtin_assume(j < 3);
             this->j = j;
@@ -1584,7 +1584,7 @@ struct ForceField
      * @param c The constants for the threadIdx^th node.
      * @return The gradient of the bond, flatness, bending and dihedral terms w.r.t. the coordinates of the threadIdx^th node.
      */
-    coord3d gradient(const Span<coord3d> X) const
+    coord3d gradient(const std::span<coord3d> X) const
     {
         sycl::group_barrier(cta);
         coord3d grad = {0.0, 0.0, 0.0};
@@ -1611,7 +1611,7 @@ struct ForceField
          }
     }
 
-    hessian_t<T, K> hessian(const Span<coord3d> X) const
+    hessian_t<T, K> hessian(const std::span<coord3d> X) const
     {
         sycl::group_barrier(cta);
         hessian_t<T, K> hess(node_graph);
@@ -1629,7 +1629,7 @@ struct ForceField
     }
 
     // Uses finite difference to compute the hessian
-    hessian_t<T, K> fd_hessian(const Span<coord3d> X, const float reldelta = 1e-7) const
+    hessian_t<T, K> fd_hessian(const std::span<coord3d> X, const float reldelta = 1e-7) const
     {
         hessian_t<T, K> hess_fd(node_graph);
         for (uint16_t i = 0; i < N; i++)
@@ -1671,7 +1671,7 @@ struct ForceField
      * @param c The constants for the threadIdx^th node.
      * @return Total energy.
      */
-    real_t energy(const Span<coord3d> X) const
+    real_t energy(const std::span<coord3d> X) const
     {
         sycl::group_barrier(cta);
         real_t arc_energy = (real_t)0.0;
@@ -1708,7 +1708,7 @@ struct ForceField
      * @param X2 memory for storing temporary coordinates at x2.
      * @return The step-size alpha
      */
-    real_t GSS(const Span<coord3d> X, const coord3d &r0, const Span<coord3d> X1, const Span<coord3d> X2) const
+    real_t GSS(const std::span<coord3d> X, const coord3d &r0, const std::span<coord3d> X1, const std::span<coord3d> X2) const
     {
         const real_t tau = (real_t)0.6180339887;
         // Line search x - values;
@@ -1762,7 +1762,7 @@ struct ForceField
      * @param X2 memory for storing temporary coordinates.
      * @param MaxIter The maximum number of iterations.
      */
-    void CG(const Span<coord3d> X, const Span<coord3d> X1, const Span<coord3d> X2, const size_t MaxIter)
+    void CG(const std::span<coord3d> X, const std::span<coord3d> X1, const std::span<coord3d> X2, const size_t MaxIter)
     {
         real_t alpha, beta, g0_norm2, s_norm;
         coord3d g0, g1, s;
@@ -1859,7 +1859,7 @@ template <ForcefieldType FFT, typename T = float, typename K = uint16_t>
 static SyclEvent forcefield_optimize_view_batch_impl(
     SyclQueue& Q,
     batch::BatchView<Spanify::RSRAdjacencyView<K>> graph,
-    Span<std::array<T,3>> xyz,
+    std::span<std::array<T,3>> xyz,
     batch::BatchStateView state,
     size_t iterations, size_t max_iterations)
 {
@@ -1867,7 +1867,7 @@ static SyclEvent forcefield_optimize_view_batch_impl(
     auto [adj_flat, deg_flat, twin_flat] = graph.spans();
     (void)deg_flat; (void)twin_flat;
 
-    Span<std::array<K,3>> A_cubic(
+    std::span<std::array<K,3>> A_cubic(
         reinterpret_cast<std::array<K,3>*>(adj_flat.data()),
         adj_flat.size() / 3);
 
@@ -1896,7 +1896,7 @@ static SyclEvent forcefield_optimize_view_batch_impl(
                 if (statuses[bid].is_set(StatusEnum::FAILED_3D) || statuses[bid].is_set(StatusEnum::CONVERGED_3D)) return;
 
                 const auto cubic_neighbours_acc = A_cubic.subspan(bid * N, N);
-                auto X_acc = xyz.subspan(bid * N, N).template as_span<coord3d>();
+                auto X_acc = as_span<coord3d>(xyz.subspan(bid * N, N));
 
                 Constants<T,K>    constants(cubic_neighbours_acc, tid);
                 NodeNeighbours<K> nodeG(cubic_neighbours_acc, tid);
@@ -1910,7 +1910,7 @@ static SyclEvent forcefield_optimize_view_batch_impl(
                 auto convergence_check = [&]() {
                     coord3d rel_bond_err, rel_angle_err, rel_dihedral_err;
                     for (int j = 0; j < 3; j++) {
-                        auto arc = typename ForceField<FFT,T,K>::ArcData(tid, j, Span<coord3d>(X.get_pointer(), N), nodeG);
+                        auto arc = typename ForceField<FFT,T,K>::ArcData(tid, j, std::span<coord3d>(static_cast<coord3d*>(X.get_pointer()), N), nodeG);
                         rel_bond_err[j]     = std::abs(arc.bond()     - constants.r0[j])         / constants.r0[j];
                         rel_angle_err[j]    = std::abs(arc.angle()    - constants.angle0[j])     / constants.angle0[j];
                         rel_dihedral_err[j] = std::abs(arc.dihedral() - constants.inner_dih0[j]) / constants.inner_dih0[j];
@@ -1926,10 +1926,10 @@ static SyclEvent forcefield_optimize_view_batch_impl(
                     }
                 };
 
-                FF.CG(Span<coord3d>(X.get_pointer(), N), Span<coord3d>(X1.get_pointer(), N), Span<coord3d>(X2.get_pointer(), N), std::max(iterations - 1, size_t(0)));
-                auto E1 = FF.energy(Span<coord3d>(X.get_pointer(), N));
-                FF.CG(Span<coord3d>(X.get_pointer(), N), Span<coord3d>(X1.get_pointer(), N), Span<coord3d>(X2.get_pointer(), N), std::min(size_t(1), iterations));
-                auto E2 = FF.energy(Span<coord3d>(X.get_pointer(), N));
+                FF.CG(std::span<coord3d>(static_cast<coord3d*>(X.get_pointer()), N), std::span<coord3d>(static_cast<coord3d*>(X1.get_pointer()), N), std::span<coord3d>(static_cast<coord3d*>(X2.get_pointer()), N), std::max(iterations - 1, size_t(0)));
+                auto E1 = FF.energy(std::span<coord3d>(static_cast<coord3d*>(X.get_pointer()), N));
+                FF.CG(std::span<coord3d>(static_cast<coord3d*>(X.get_pointer()), N), std::span<coord3d>(static_cast<coord3d*>(X1.get_pointer()), N), std::span<coord3d>(static_cast<coord3d*>(X2.get_pointer()), N), std::min(size_t(1), iterations));
+                auto E2 = FF.energy(std::span<coord3d>(static_cast<coord3d*>(X.get_pointer()), N));
                 if ((std::abs(E1 - E2)/N < std::numeric_limits<T>::epsilon()*1e2) || ((size_t)iters[bid] >= max_iterations))
                     check_convergence = true;
                 if (check_convergence) convergence_check();
@@ -1944,7 +1944,7 @@ template <ForcefieldType FFT, typename T, typename K>
 SyclEvent ForcefieldOptimizeFunctor<FFT,T,K>::compute(
     SyclQueue& Q,
     batch::BatchView<Spanify::RSRAdjacencyView<K>> graph,
-    Span<std::array<T,3>> xyz,
+    std::span<std::array<T,3>> xyz,
     batch::BatchStateView state,
     size_t batch_iters, size_t max_iters) {
     return forcefield_optimize_view_batch_impl<FFT,T,K>(Q, graph, xyz, state, batch_iters, max_iters);

--- a/src/sycl/geometry-properties.cc
+++ b/src/sycl/geometry-properties.cc
@@ -6,7 +6,7 @@
 #include "forcefield-includes.cc"
 
 template <typename T>
-symMat3<T> inertia_matrix(sycl::group<1>& cta, const Span<std::array<T,3>> X){
+symMat3<T> inertia_matrix(sycl::group<1>& cta, const std::span<std::array<T,3>> X){
     auto tid = cta.get_local_id(0);
     symMat3<T> I;
     T diag = sycl::reduce_over_group(cta, dot(X[tid], X[tid]), sycl::plus<T>());
@@ -23,7 +23,7 @@ symMat3<T> inertia_matrix(sycl::group<1>& cta, const Span<std::array<T,3>> X){
 }
 
 template <typename T>
-auto inertia_matrix(SyclQueue& Q, const Span<std::array<T,3>> X){
+auto inertia_matrix(SyclQueue& Q, const std::span<std::array<T,3>> X){
     symMat3<T> I;
     Q.wait();
     T diag = std::transform_reduce(FULLERENE_PAR_UNSEQ X.begin(), X.end(), T(0), std::plus<T>{}, [](const auto& x) -> T {return dot(x,x);});
@@ -40,14 +40,14 @@ auto inertia_matrix(SyclQueue& Q, const Span<std::array<T,3>> X){
 }
 
 template <typename T>
-auto principal_axes(SyclQueue& Q, const Span<std::array<T,3>> X){
+auto principal_axes(SyclQueue& Q, const std::span<std::array<T,3>> X){
     auto I = inertia_matrix(Q, X);
     auto [V,lambdas] = I.eigensystem();
     return V;
 }
 
 template <typename T>
-std::array<std::array<T,3>,3> principal_axes(sycl::group<1>& cta, const Span<std::array<T,3>> X){
+std::array<std::array<T,3>,3> principal_axes(sycl::group<1>& cta, const std::span<std::array<T,3>> X){
     auto I = inertia_matrix(cta,X);
     auto [V,lambdas] = I.eigensystem();
     return V;
@@ -65,8 +65,8 @@ template<typename T, typename K> struct SurfaceAreaFunctorView;
 template<typename T, typename K> struct VolumeFunctorView;
 
 template <typename T, typename K>
-SyclEvent EccentricityFunctor<T,K>::compute(SyclQueue& Q, Span<std::array<T,3>> xyz, int N, int capacity,
-                                             batch::BatchStateView state, Span<T> out_ellipticity) {
+SyclEvent EccentricityFunctor<T,K>::compute(SyclQueue& Q, std::span<std::array<T,3>> xyz, int N, int capacity,
+                                             batch::BatchStateView state, std::span<T> out_ellipticity) {
     auto statuses = state.status;
     SyclEventImpl ret_val = Q->submit([=](sycl::handler& cgh) {
         cgh.parallel_for<struct EccentricityFunctorView<T,K>>(
@@ -86,8 +86,8 @@ SyclEvent EccentricityFunctor<T,K>::compute(SyclQueue& Q, Span<std::array<T,3>> 
 }
 
 template <typename T, typename K>
-SyclEvent InertiaFunctor<T,K>::compute(SyclQueue& Q, Span<std::array<T,3>> xyz, int N, int capacity,
-                                        batch::BatchStateView state, Span<std::array<T,3>> out_inertia) {
+SyclEvent InertiaFunctor<T,K>::compute(SyclQueue& Q, std::span<std::array<T,3>> xyz, int N, int capacity,
+                                        batch::BatchStateView state, std::span<std::array<T,3>> out_inertia) {
     auto statuses = state.status;
     SyclEventImpl ret_val = Q->submit([=](sycl::handler& cgh) {
         cgh.parallel_for<struct InertiaFunctorView<T,K>>(
@@ -106,7 +106,7 @@ SyclEvent InertiaFunctor<T,K>::compute(SyclQueue& Q, Span<std::array<T,3>> xyz, 
 }
 
 template <typename T, typename K>
-SyclEvent TransformCoordinatesFunctor<T,K>::compute(SyclQueue& Q, Span<std::array<T,3>> xyz, int N, int capacity,
+SyclEvent TransformCoordinatesFunctor<T,K>::compute(SyclQueue& Q, std::span<std::array<T,3>> xyz, int N, int capacity,
                                                      batch::BatchStateView state) {
     auto statuses = state.status;
     SyclEventImpl ret_val = Q->submit([=](sycl::handler& cgh) {
@@ -129,9 +129,9 @@ SyclEvent TransformCoordinatesFunctor<T,K>::compute(SyclQueue& Q, Span<std::arra
 }
 
 template <typename T, typename K>
-SyclEvent SurfaceAreaFunctor<T,K>::compute(SyclQueue& Q, Span<std::array<T,3>> xyz, int N, int capacity,
-                                            Span<std::array<K,6>> faces, Span<uint8_t> deg,
-                                            batch::BatchStateView state, Span<T> out_surface_area) {
+SyclEvent SurfaceAreaFunctor<T,K>::compute(SyclQueue& Q, std::span<std::array<T,3>> xyz, int N, int capacity,
+                                            std::span<std::array<K,6>> faces, std::span<uint8_t> deg,
+                                            batch::BatchStateView state, std::span<T> out_surface_area) {
     FLOAT_TYPEDEFS(T);
     auto statuses = state.status;
     const int Nf = N / 2 + 2;
@@ -168,9 +168,9 @@ SyclEvent SurfaceAreaFunctor<T,K>::compute(SyclQueue& Q, Span<std::array<T,3>> x
 }
 
 template <typename T, typename K>
-SyclEvent VolumeFunctor<T,K>::compute(SyclQueue& Q, Span<std::array<T,3>> xyz, int N, int capacity,
-                                       Span<std::array<K,6>> faces, Span<uint8_t> deg,
-                                       batch::BatchStateView state, Span<T> out_volume) {
+SyclEvent VolumeFunctor<T,K>::compute(SyclQueue& Q, std::span<std::array<T,3>> xyz, int N, int capacity,
+                                       std::span<std::array<K,6>> faces, std::span<uint8_t> deg,
+                                       batch::BatchStateView state, std::span<T> out_volume) {
     FLOAT_TYPEDEFS(T);
     auto statuses = state.status;
     const int Nf = N / 2 + 2;

--- a/src/sycl/hessian.cc
+++ b/src/sycl/hessian.cc
@@ -59,7 +59,7 @@ struct ForceField
         node_t node_id;
         sycl::group<1> cta;
         // 84 + 107 FLOPS
-        FaceData(const sycl::group<1> &cta, const Span<coord3d> X, const NodeNeighbours<K> &G) : cta(cta)
+        FaceData(const sycl::group<1> &cta, const std::span<coord3d> X, const NodeNeighbours<K> &G) : cta(cta)
         {
             node_id = cta.get_local_linear_id();
             N = cta.get_local_linear_range();
@@ -184,7 +184,7 @@ struct ForceField
          * @param G The neighbour information for the threadIdx^th node.
          * @return A new ArcData object.
          */
-        ArcData(node_t a, const int j, const Span<coord3d> X, const NodeNeighbours<K> &G)
+        ArcData(node_t a, const int j, const std::span<coord3d> X, const NodeNeighbours<K> &G)
         {
             __builtin_assume(j < 3);
             this->j = j;
@@ -1575,7 +1575,7 @@ struct ForceField
      * @param c The constants for the threadIdx^th node.
      * @return The gradient of the bond, flatness, bending and dihedral terms w.r.t. the coordinates of the threadIdx^th node.
      */
-    coord3d gradient(const Span<coord3d> X) const
+    coord3d gradient(const std::span<coord3d> X) const
     {
         sycl::group_barrier(cta);
         coord3d grad = {0.0, 0.0, 0.0};
@@ -1602,7 +1602,7 @@ struct ForceField
          }
     }
 
-    hessian_t<T, K> hessian(const Span<coord3d> X) const
+    hessian_t<T, K> hessian(const std::span<coord3d> X) const
     {
         sycl::group_barrier(cta);
         hessian_t<T, K> hess(node_graph, node_id);
@@ -1620,7 +1620,7 @@ struct ForceField
     }
 
     // Uses finite difference to compute the hessian
-    hessian_t<T, K> fd_hessian(const Span<coord3d> X, const float reldelta = 1e-7) const
+    hessian_t<T, K> fd_hessian(const std::span<coord3d> X, const float reldelta = 1e-7) const
     {
         hessian_t<T, K> hess_fd(node_graph, node_id);
         for (uint16_t i = 0; i < N; i++)
@@ -1662,7 +1662,7 @@ struct ForceField
      * @param c The constants for the threadIdx^th node.
      * @return Total energy.
      */
-    real_t energy(const Span<coord3d> X) const
+    real_t energy(const std::span<coord3d> X) const
     {
         sycl::group_barrier(cta);
         real_t arc_energy = (real_t)0.0;
@@ -1699,7 +1699,7 @@ struct ForceField
      * @param X2 memory for storing temporary coordinates at x2.
      * @return The step-size alpha
      */
-    real_t GSS(const Span<coord3d> X, const coord3d &r0, const Span<coord3d> X1, const Span<coord3d> X2) const
+    real_t GSS(const std::span<coord3d> X, const coord3d &r0, const std::span<coord3d> X1, const std::span<coord3d> X2) const
     {
         const real_t tau = (real_t)0.6180339887;
         // Line search x - values;
@@ -1753,7 +1753,7 @@ struct ForceField
      * @param X2 memory for storing temporary coordinates.
      * @param MaxIter The maximum number of iterations.
      */
-    void CG(const Span<coord3d> X, const Span<coord3d> X1, const Span<coord3d> X2, const size_t MaxIter)
+    void CG(const std::span<coord3d> X, const std::span<coord3d> X1, const std::span<coord3d> X2, const size_t MaxIter)
     {
         real_t alpha, beta, g0_norm2, s_norm;
         coord3d g0, g1, s;
@@ -1813,15 +1813,15 @@ template <ForcefieldType FFT, typename T, typename K>
 static SyclEvent compute_hessians_view(
     SyclQueue& Q,
     batch::BatchView<Spanify::RSRAdjacencyView<K>> graph,
-    Span<std::array<T,3>> xyz,
+    std::span<std::array<T,3>> xyz,
     batch::BatchStateView state,
-    Span<T> hess, Span<K> cols)
+    std::span<T> hess, std::span<K> cols)
 {
     TEMPLATE_TYPEDEFS(T,K);
     auto [adj_flat, deg_flat, twin_flat] = graph.spans();
     (void)deg_flat; (void)twin_flat;
 
-    Span<std::array<K,3>> A_cubic(
+    std::span<std::array<K,3>> A_cubic(
         reinterpret_cast<std::array<K,3>*>(adj_flat.data()),
         adj_flat.size() / 3);
 
@@ -1845,19 +1845,19 @@ static SyclEvent compute_hessians_view(
             if (statuses[bid].is_not_set(StatusEnum::FULLERENEGRAPH_PREPARED)) return;
 
             const auto cubic_neighbours_acc = A_cubic.subspan(bid * N, N);
-            const auto X_acc = xyz.subspan(bid * N, N).template as_span<coord3d>();
+            const auto X_acc = as_span<coord3d>(xyz.subspan(bid * N, N));
 
             Constants<T,K>    constants(cubic_neighbours_acc, K(tid));
             NodeNeighbours<K> nodeG(cubic_neighbours_acc, K(tid));
             X_smem[tid] = X_acc[tid];
             ForceField<FFT,T,K> FF(nodeG, constants, cta, sdata.get_pointer());
-            auto hessian = FF.hessian(Span<coord3d>(X_smem.get_pointer(), N));
+            auto hessian = FF.hessian(std::span<coord3d>(static_cast<coord3d*>(X_smem.get_pointer()), N));
             int n_cols = 10*3;
             int n_rows = N*3;
             int hess_stride = n_cols*n_rows;
             int toff = bid*hess_stride + tid*n_cols*3;
-            Span<T> hess_span = hess.subspan(toff, n_cols*3);
-            Span<K> cols_span = cols.subspan(toff, n_cols*3);
+            std::span<T> hess_span = hess.subspan(toff, n_cols*3);
+            std::span<K> cols_span = cols.subspan(toff, n_cols*3);
             for (size_t i = 0; i < 3; i++)
             for (size_t j = 0; j < 10; j++) {
                 for (size_t k = 0; k < 3; k++) {
@@ -1889,9 +1889,9 @@ template <ForcefieldType FFT, typename T, typename K>
 SyclEvent HessianFunctor<FFT,T,K>::compute(
     SyclQueue& Q,
     batch::BatchView<Spanify::RSRAdjacencyView<K>> graph,
-    Span<std::array<T,3>> xyz,
+    std::span<std::array<T,3>> xyz,
     batch::BatchStateView state,
-    Span<T> out_hessian, Span<K> out_cols) {
+    std::span<T> out_hessian, std::span<K> out_cols) {
     return compute_hessians_view<FFT,T,K>(Q, graph, xyz, state, out_hessian, out_cols);
 }
 

--- a/src/sycl/lanczos.cc
+++ b/src/sycl/lanczos.cc
@@ -156,7 +156,7 @@ std::array<T,2> eigvalsh2x2(const std::array<T,4> &A){
 }
 //Assumes A is symmetric
 template <typename T, int N> 
-void lanczos(sycl::group<1>& cta, Span<T> A, Span<T> X, Span<T> alphas, Span<T> betas, Span<T> Vspan){
+void lanczos(sycl::group<1>& cta, std::span<T> A, std::span<T> X, std::span<T> alphas, std::span<T> betas, std::span<T> Vspan){
     auto tid = cta.get_local_linear_id();
     T* V = Vspan.data() + tid;
 

--- a/src/sycl/node-neighbours.cc
+++ b/src/sycl/node-neighbours.cc
@@ -12,7 +12,7 @@ struct NodeNeighbours{
     
 
 
-    /* NodeNeighbours(sycl::group<1> cta, const Span<std::array<K,3>> cubic_neighbours_acc, K* sdata){
+    /* NodeNeighbours(sycl::group<1> cta, const std::span<std::array<K,3>> cubic_neighbours_acc, K* sdata){
         INT_TYPEDEFS(K);
         face_nodes.fill(UINT16_MAX);
         face_neighbours.fill(UINT16_MAX);
@@ -63,7 +63,7 @@ struct NodeNeighbours{
      * @return NodeNeighbours object.
      */
 
-    NodeNeighbours(const Span<std::array<K,3>> cubic_neighbours_acc, K tid){
+    NodeNeighbours(const std::span<std::array<K,3>> cubic_neighbours_acc, K tid){
         const DeviceCubicGraph FG(cubic_neighbours_acc);
         this->cubic_neighbours   = {FG[tid][0], FG[tid][1], FG[tid][2]};
         this->next_on_face = {FG.next_on_face(tid, FG[tid][0]), FG.next_on_face(tid, FG[tid][1]), FG.next_on_face(tid ,FG[tid][2])};

--- a/src/sycl/spherical-projection.cc
+++ b/src/sycl/spherical-projection.cc
@@ -123,7 +123,7 @@ CuDeque(const local_accessor<T,1> memory, const int capacity): array(memory), fr
 };
 
 template <typename K>
-K multiple_source_shortest_paths(const sycl::group<1>& cta, const Span<std::array<K,3>> cubic_neighbours,const local_accessor<int,1>& distances, const local_accessor<K,1>& smem){
+K multiple_source_shortest_paths(const sycl::group<1>& cta, const std::span<std::array<K,3>> cubic_neighbours,const local_accessor<int,1>& distances, const local_accessor<K,1>& smem){
     INT_TYPEDEFS(K);
     auto N = cta.get_local_linear_range();
     auto tid = cta.get_local_linear_id();
@@ -162,8 +162,8 @@ template <typename T, typename K>
 static SyclEvent spherical_projection_view_batch_impl(
     SyclQueue& Q,
     batch::BatchView<Spanify::RSRAdjacencyView<K>> graph,
-    Span<std::array<T,2>> layout_2d,
-    Span<std::array<T,3>> xyz_3d,
+    std::span<std::array<T,2>> layout_2d,
+    std::span<std::array<T,3>> xyz_3d,
     batch::BatchStateView state)
 {
     TEMPLATE_TYPEDEFS(T,K);
@@ -172,10 +172,10 @@ static SyclEvent spherical_projection_view_batch_impl(
     auto [adj_flat, deg_flat, twin_flat] = graph.spans();
     (void)deg_flat; (void)twin_flat;
 
-    Span<std::array<K,3>> A_cubic(
+    std::span<std::array<K,3>> A_cubic(
         reinterpret_cast<std::array<K,3>*>(adj_flat.data()),
         adj_flat.size() / 3);
-    Span<coord2d> layout_cd(
+    std::span<coord2d> layout_cd(
         reinterpret_cast<coord2d*>(layout_2d.data()),
         layout_2d.size());
 
@@ -249,8 +249,8 @@ template <typename T, typename K>
 SyclEvent SphericalProjectionFunctor<T,K>::compute(
     SyclQueue& Q,
     batch::BatchView<Spanify::RSRAdjacencyView<K>> graph,
-    Span<std::array<T,2>> layout_2d,
-    Span<std::array<T,3>> xyz_3d,
+    std::span<std::array<T,2>> layout_2d,
+    std::span<std::array<T,3>> xyz_3d,
     batch::BatchStateView state) {
     return spherical_projection_view_batch_impl<T,K>(Q, graph, layout_2d, xyz_3d, state);
 }

--- a/src/sycl/sycl-util-impl.cc
+++ b/src/sycl/sycl-util-impl.cc
@@ -134,7 +134,7 @@ SyclVector<T>& SyclVector<T>::operator=(const SyclVector<T>& other) {
 
 template <typename U>
 std::ostream& operator<<(std::ostream& os, const SyclVector<U>& vec) {
-    os << (Span<U>)vec;
+    os << (std::span<U>)vec;
     return os;
 }
 

--- a/src/sycl/tutte.cc
+++ b/src/sycl/tutte.cc
@@ -25,7 +25,7 @@ template <typename T, typename K>
 static SyclEvent tutte_view_batch_impl(
     SyclQueue& Q,
     batch::BatchView<Spanify::RSRAdjacencyView<K>> graph,
-    Span<std::array<T,2>> layout,
+    std::span<std::array<T,2>> layout,
     batch::BatchStateView state)
 {
     TEMPLATE_TYPEDEFS(T,K);
@@ -33,11 +33,11 @@ static SyclEvent tutte_view_batch_impl(
     (void)deg_flat; (void)twin_flat;
 
     // Reinterpret flat K* as array<K,3>* (dmax==3 for cubic)
-    Span<std::array<K,3>> A_cubic(
+    std::span<std::array<K,3>> A_cubic(
         reinterpret_cast<std::array<K,3>*>(adj_flat.data()),
         adj_flat.size() / 3);
     // coord2d == std::array<T,2> (see FLOAT_TYPEDEFS macro)
-    Span<coord2d> layout_cd(
+    std::span<coord2d> layout_cd(
         reinterpret_cast<coord2d*>(layout.data()),
         layout.size());
 
@@ -115,7 +115,7 @@ static SyclEvent tutte_view_batch_impl(
 template <typename T, typename K>
 SyclEvent TutteFunctor<T,K>::compute(SyclQueue& Q,
                                      batch::BatchView<Spanify::RSRAdjacencyView<K>> graph,
-                                     Span<std::array<T,2>> layout,
+                                     std::span<std::array<T,2>> layout,
                                      batch::BatchStateView state) {
     return tutte_view_batch_impl<T,K>(Q, graph, layout, state);
 }

--- a/tests/sycl-tests/mdspan-test.cc
+++ b/tests/sycl-tests/mdspan-test.cc
@@ -33,8 +33,8 @@ TEST(MDSPan, StridedAccess)
             }
     std::cout << "data = " << data << "\n";
 
-    std::cout << "span.stride = "  << Span( span.stride().data(),3) << "\n";
-    std::cout << "spanT.stride = " << Span(spanT.stride().data(),3) << "\n";
+    std::cout << "span.stride = "  << std::span( span.stride().data(),3) << "\n";
+    std::cout << "spanT.stride = " << std::span(spanT.stride().data(),3) << "\n";
 
     
     std::cout << "span = ";
@@ -67,10 +67,10 @@ TEST(SpanMatrix, CoalesceTest)
     
     for(int i=0;i<4;i++){
         SpanMatrix Ai = A({i,0,0}, 3,3);
-        std::cout << "A.shape = " << Span(Ai.shape().data(),2) << "\n";
+        std::cout << "A.shape = " << std::span(Ai.shape().data(),2) << "\n";
         std::cout << "A"<<i << " = \n" << Ai << "\n";
     }
-    std::cout << "A.data()" << Span(A.data(),m*n*p) << "\n";
+    std::cout << "A.data()" << std::span(A.data(),m*n*p) << "\n";
 }
 
 TEST(SpanMatrix, QHQ_test)
@@ -235,7 +235,7 @@ TEST(SyclVector, InequalityOperator)
 TEST(SyclVector, SpanConstructor)
 {
     SyclVector<int> vec(10, 5);
-    Span<int> span(vec);
+    std::span<int> span(vec);
     EXPECT_EQ(span.size(), 10);
     for (int i = 0; i < 10; i++)
     {

--- a/tests/sycl-tests/sycl-vector-test.cc
+++ b/tests/sycl-tests/sycl-vector-test.cc
@@ -147,7 +147,7 @@ TEST(SyclVector, InequalityOperator)
 TEST(SyclVector, SpanConstructor)
 {
     SyclVector<int> vec(10, 5);
-    Span<int> span(vec);
+    std::span<int> span(vec);
     EXPECT_EQ(span.size(), 10);
     for (int i = 0; i < 10; i++)
     {


### PR DESCRIPTION
## Summary

Removes the custom `Span<T>` wrapper class entirely and replaces all usages with `std::span<T>` directly.

## Changes

**`include/fullerenes/sycl-headers/sycl-span.hh`**
- Removed the `Span<T>` subclass of `std::span<T>`
- Added a free function `as_span<U>(std::span<T>)` to replace the `.as_span<U>()` member method
- Kept `operator<<`, `span_fuzzy_equal`, and `operator==` helpers

**`include/fullerenes/kernel-headers/base-functor.hh`**
- Added `is_std_span<T>` trait to replace `is_specialization_of<Span, T>` — `std::span` has a non-type `Extent` parameter that the variadic template specialization cannot match

**`src/sycl/hessian.cc`, `forcefield-optimize.cc`, `dualize.cc`**
- Added `static_cast<T*>()` around SYCL `local_accessor::get_pointer()` calls when constructing `std::span` — SYCL `multi_ptr` is not a C++ contiguous iterator

**`src/sycl/hessian.cc`, `eigen.cc`, `forcefield-optimize.cc`**
- Changed `.template as_span<U>()` member calls to `as_span<U>(...)` free function calls

**All other files (31 total)**
- Bulk-replaced `Span<T>` to `std::span<T>` and `Span(...)` to `std::span(...)`